### PR TITLE
Three and Four of a Kind should score sum of all dice

### DIFF
--- a/BlazorYahtzee/Models/Categories/FourOfAKind.cs
+++ b/BlazorYahtzee/Models/Categories/FourOfAKind.cs
@@ -24,7 +24,7 @@ namespace BlazorYahtzee.Models.Categories
 
         public int PointsFor(Player player)
         {
-            return player.Dice.SumOfAKind(4);
+            return player.Dice.SumOfAll();
         }
     }
 }

--- a/BlazorYahtzee/Models/Categories/ThreeOfAKind.cs
+++ b/BlazorYahtzee/Models/Categories/ThreeOfAKind.cs
@@ -24,7 +24,7 @@ namespace BlazorYahtzee.Models.Categories
 
         public int PointsFor(Player player)
         {
-            return player.Dice.SumOfAKind(3);
+            return player.Dice.SumOfAll();
         }
     }
 }


### PR DESCRIPTION
See rules at https://en.wikipedia.org/wiki/Yahtzee#Lower_section

![image](https://user-images.githubusercontent.com/1652014/110235802-ee19ff80-7f29-11eb-94b3-bbb348dbf6bb.png)

If the different play modes require this to be scored differently, then this PR will not be correct.

Also note: I have not altered the scoring for Pair and Two Pair (which are in Plus Mode only).  